### PR TITLE
Improve setting on Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - composer self-update
 
 install:
-  - if [[ "$(phpenv version-name)" == "nightly" ]]; then composer update --ignore-platform-reqs; else composer install --dev --prefer-source; fi;
+  - if [[ "$(phpenv version-name)" == "nightly" ]]; then composer update --ignore-platform-reqs; else composer install --prefer-source; fi;
 
 script:
   - vendor/bin/phpunit


### PR DESCRIPTION
# Changed log
- Removing `--dev` option because this is deprecated option. And the deprecated warning message is as follows:

```
You are using the deprecated option "dev". Dev packages are installed by default now.
```
- Add EOF (end of file) for this `.travis.yml` setting file.
